### PR TITLE
Add support for events without explicit end date

### DIFF
--- a/convertcal.py
+++ b/convertcal.py
@@ -28,7 +28,11 @@ def do_one_ics(ics, default_location):
     all_events = []
     for ev_id, event in enumerate(cal.walk('vevent')):
         d = event.get('dtstart').dt
-        de = event.get('dtend').dt
+        de = get_end_date(event, d)
+        if not de:
+            print("Skipping event: %s" % event.get('summary'))
+            continue
+
         location = event.get('location', default_location)
         description = event.get('description', '')
         is_all_day = False
@@ -76,6 +80,19 @@ def do_one_ics(ics, default_location):
         all_events.append(current)
 
     return all_events
+
+
+def get_end_date(event, start_date):
+    dtend = event.get('dtend')
+    if dtend:
+        end_date = dtend.dt
+    else:
+        duration = event.get('duration')
+        if not duration:
+            return None
+        end_date = start_date + duration.dt
+
+    return end_date
 
 
 export_name = os.path.join(os.path.dirname(__file__), 'html', 'exported', 'events.js')


### PR DESCRIPTION
`regulars.ics` now contains an event with `DURATION` instead of `DTEND`.

<pre>
BEGIN:VEVENT
DTSTAMP:20161207T133633Z
UID:9e051d3e-1ce6-401c-b131-5b2a25e80cbc
SEQUENCE:2
DTSTART;TZID=Europe/Berlin:20160127T190000
<b>DURATION:PT4H</b>
RRULE:FREQ=MONTHLY;WKST=MO;UNTIL=20160727T165959Z;BYDAY=-1WE
EXDATE:20150930T170000Z
SUMMARY:Android Stammtisch
LOCATION:android-in-berlin.de
DESCRIPTION:http://android-in-berlin.de
CLASS:PUBLIC
CREATED:20150720T213310Z
X-LIC-ERROR;X-LIC-ERRORTYPE=VALUE-PARSE-ERROR:No value for CATEGORIES prope
 rty. Removing entire property:
END:VEVENT
</pre>